### PR TITLE
adding check for windows then using Scripts instead of bin

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -92,7 +92,9 @@ def _activate_virtualenv(topdir):
     if python is None:
         sys.exit("Python is not installed. Please install it prior to running mach.")
 
-    activate_path = os.path.join(virtualenv_path, "bin", "activate_this.py")
+    # Virtualenv calls its scripts folder "bin" on linux/OSX but "Scripts" on Windows, detect which one then use that
+    script_dir = "Scripts" if os.name == "nt" else "bin"
+    activate_path = os.path.join(virtualenv_path, script_dir, "activate_this.py")
     if not (os.path.exists(virtualenv_path) and os.path.exists(activate_path)):
         virtualenv = _get_exec(*VIRTUALENV_NAMES)
         if virtualenv is None:


### PR DESCRIPTION
@larsbergstrom 
This pushes us a little bit further, at least now the virtualenv stuff runs
however...

```
λ python mach build --dev
looking for rustc at C:\Users\Jason\workspace\servo\.servo\rust\2015-11-26/rustc-nightly-i686-unknown\rustc\bin\rustc.exe
Downloading Rust compiler...
Download failed (403): Forbidden - https://static-rust-lang-org.s3.amazonaws.com/dist/2015-11-26/rustc-nightly-i686-unknown.tar.gz
```